### PR TITLE
Python Snippets Set to Total

### DIFF
--- a/autotest/autotests.yml
+++ b/autotest/autotests.yml
@@ -11,7 +11,7 @@ python:
 
     testfile_template: "from code_feedback import Feedback\nfrom pl_helpers import name, points\nfrom utils import source_ans, source_student, MyTestCase\n\n\nclass Test(MyTestCase):\n"
     dispatch: "type({{snippet}})"
-    test_case_template: "    @points({{score}})\n    @name('test {{test_expr}}')\n    def test_{{count}}(self):\n        ans_env = source_ans({{solution_params}})\n        student_env = source_student({{submission_params}})\n        if Feedback.{{check_fn}}('{{test_expr}}', eval('{{test_expr}}', ans_env), eval('{{test_expr}}', student_env)):\n            Feedback.set_score({{score}})\n        else:\n            Feedback.set_score(0)\n\n"
+    test_case_template: "    @points({{score}})\n    @name('test {{test_expr}}')\n    def test_{{count}}(self):\n        ans_env = source_ans({{solution_params}})\n        student_env = source_student({{submission_params}})\n        if Feedback.{{check_fn}}('{{test_expr}}', eval('{{test_expr}}', ans_env), eval('{{test_expr}}', student_env)):\n            Feedback.set_score(1)\n        else:\n            Feedback.set_score(0)\n\n"
 
     test_expr_templates:
         scalar:


### PR DESCRIPTION
Python `set_score` is awarded as a percentage of `@points` - current method was using `score / snippets` for both `@points` and `set_score` which meant the question was essentially only awarding a fractional result for correct answers instead of 100%

Updated `autotests.yml` to simply award 1 when correct in the Python template.

Alternatively could change this to a separate value and set the value in `instantiatetests.py` but this was the easiest option as I do not see when we would want a non-100% score for a correct answer to justify assigning to variable.