### PR TITLE
Updates for convert_autograde.py

### DIFF
--- a/question_bank/convert_autograde.py
+++ b/question_bank/convert_autograde.py
@@ -40,10 +40,7 @@ with open("{}/question.html".format(question_folder), "r") as f:
     question_html = f.read()
 
 # Situations that require a test folder to be created
-test_conditions = [
-    args.question_type == "coding", 
-    args.create_data_file == True
-]
+test_conditions = [args.question_type == "coding", args.create_data_file == True]
 
 # Create test folder if required
 if any(test_conditions):
@@ -68,14 +65,14 @@ if args.create_server_file:
                 'import prairielearn as pl\nimport pandas as pd\n\n\ndef generate(data):\n    df = pd.read_csv("tests/data.txt")\n    data["params"]["df"] = pl.to_json(df.head(10))\n'
             )
 
-    # Check for data_file
-    if args.create_data_file:
-        # create an empty data.txt. Note we need to add data manually
-        data_file_name = "{}/data.txt".format(test_folder)
-        if os.path.exists(data_file_name) is False:
-            print(f"create {data_file_name}")
-            with open(data_file_name, "w") as f:
-                f.write("")
+# Check for data_file
+if args.create_data_file:
+    # create an empty data.txt. Note we need to add data manually
+    data_file_name = "{}/data.txt".format(test_folder)
+    if os.path.exists(data_file_name) is False:
+        print(f"create {data_file_name}")
+        with open(data_file_name, "w") as f:
+            f.write("")
 
 # update tags in info.json
 tag_list = question_info["tags"]
@@ -245,7 +242,7 @@ course_json = "{}/infoCourse.json".format(args.pl_repo)
 if os.path.exists(course_json):
     with open(course_json, "r") as f:
         course_info = json.load(f)
-    current_question_types = [tag['name'] for tag in course_info['tags']]
+    current_question_types = [tag["name"] for tag in course_info["tags"]]
     if args.question_type not in current_question_types:
         print(
             f"question_type '{args.question_type}' is not in '{course_json}' - you may need to create it manually"


### PR DESCRIPTION
Here are some updates to the `convert_autograde.py` file. I have done some basic testing but might be worth another once over just in case.

I could not see a time where `data.txt` would be needed when `server.py` does not exist so I switched the ordering of them. I also removed them from the `MCQ` code and put at the top of the script as there are times where a different `question_type` may want to use them. As a result I needed to move the create test folder code to above this to allow for them to be created. I also included a list of conditions for potential occasions when a test folder is created so it can be referred to on multiple occasions. Might be worth extracting to a function instead in a future update?

I moved the check for `gradingMethod` outside of the `question_type` code so that it is removed for all options to close #24 

Finally I added a warning at the end of the script that notifies the user if the `question_type` that they are trying to create does not exist in the `infoCourse.json` file so that they know to go update it. This is different to the `assert args.question_type ... ` statement as the `infoCourse.json` is for in use options not all possible options.